### PR TITLE
Bump nixpkgs rev in flake.lock to pick up wxPython 4.2.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,7 +24,7 @@
         "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "f90f7a646ab118ba24ac48c93cc9cc39e4127b93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update pinned nixpkgs rev in flake.lock so python3Packages.wxpython is 4.2.5 (see upstream nixpkgs bump: https://github.com/NixOS/nixpkgs/commit/f90f7a646ab118ba24ac48c93cc9cc39e4127b93). This should make CI/Nix pick wxPython 4.2.5 in builds. The branch contains one commit that updates flake.lock:

    Commit: https://github.com/Kepas-Beleglorn/EDXD/commit/cca2d557b8e8b2fbb5f510847db00b197c333a90
